### PR TITLE
Add support for Windows

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -126,12 +126,12 @@ static void engine_parse_cmd(const char *cmd, str_t *cwd, str_t *run, str_t **ar
         vec_push(*args, str_init_from(token), str_t);
 }
 
-void Engine::engine_init(Worker *w, const char *cmd, const char *name, const str_t *options, bool debug)
+void Engine::engine_init(Worker *w, const char *cmd, const char *engname, const str_t *options, bool debug)
 {
     if (!*cmd)
         DIE("[%d] missing command to start engine.\n", w->id);
 
-    this->name = str_init_from_c(*name ? name : cmd); // default value
+    this->name = str_init_from_c(*engname ? engname : cmd); // default value
     this->isDebug = debug;
 
     // Parse cmd into (cwd, run, args): we want to execute run from cwd with args.
@@ -192,7 +192,7 @@ void Engine::engine_readln(const Worker *w, str_t *line)
         DIE_IF(w->id, fprintf(w->log, "%s -> %s\n", name.buf, line->buf) < 0);
 }
 
-void Engine::engine_writeln(const Worker *w, char *buf)
+void Engine::engine_writeln(const Worker *w, const char *buf)
 {
     DIE_IF(w->id, fputs(buf, out) < 0);
     DIE_IF(w->id, fputc('\n', out) < 0);
@@ -278,7 +278,7 @@ static void parse_and_display_engine_about(str_t &line) {
     int flag = 0;
     std::vector<std::string> tokens;
     std::stringstream ss;
-    for (int i = 0; i < line.len; i++) {
+    for (size_t i = 0; i < line.len; i++) {
         char ch = line.buf[i];
         if (ch == '\"') {
             flag = (flag + 1) % 2;
@@ -304,7 +304,7 @@ static void parse_and_display_engine_about(str_t &line) {
     std::string author = "?";
     std::string version = "?";
     std::string country = "?";
-    for (int i = 0; i < tokens.size(); i++) {
+    for (size_t i = 0; i < tokens.size(); i++) {
         if (tokens[i] == "name") {
             if ((i + 1) < tokens.size()) {
                 name = tokens[i + 1];

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -61,6 +61,20 @@ static void engine_spawn(const Worker *w, Engine *e,
     // Pipe handler: read=0, write=1
     HANDLE p_stdin[2], p_stdout[2];
 
+    // Setup job handler and job info
+    HANDLE hJob = CreateJobObject(NULL, NULL);
+    DIE_IF(w->id, !hJob);
+
+    JOBOBJECT_BASIC_LIMIT_INFORMATION jobBasicInfo;
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobExtendedInfo;
+    ZeroMemory(&jobBasicInfo, sizeof(JOBOBJECT_BASIC_LIMIT_INFORMATION));
+    ZeroMemory(&jobExtendedInfo, sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+
+    jobBasicInfo.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    jobExtendedInfo.BasicLimitInformation = jobBasicInfo;
+    DIE_IF(w->id, !SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, 
+        &jobExtendedInfo, sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION)));
+
     // Create a pipe for child process's STDOUT
     DIE_IF(w->id, !CreatePipe(&p_stdout[0], &p_stdout[1], &saAttr, 0));
     DIE_IF(w->id, !SetHandleInformation(p_stdout[0], HANDLE_FLAG_INHERIT, 0));
@@ -73,7 +87,7 @@ static void engine_spawn(const Worker *w, Engine *e,
     PROCESS_INFORMATION piProcInfo; 
     STARTUPINFO siStartInfo;
     ZeroMemory(&piProcInfo, sizeof(PROCESS_INFORMATION));
-    ZeroMemory( &siStartInfo, sizeof(STARTUPINFO) );
+    ZeroMemory(&siStartInfo, sizeof(STARTUPINFO));
     siStartInfo.cb = sizeof(STARTUPINFO); 
     siStartInfo.hStdOutput = p_stdout[1];
     siStartInfo.hStdInput = p_stdin[0];
@@ -84,7 +98,6 @@ static void engine_spawn(const Worker *w, Engine *e,
     char fullcmd[32768];
     strcpy_s(fullcmd, cmd);
     const int flag = CREATE_NO_WINDOW | BELOW_NORMAL_PRIORITY_CLASS;
-
 
     if (!CreateProcess(
         NULL,           // application name
@@ -117,6 +130,11 @@ static void engine_spawn(const Worker *w, Engine *e,
     DIE_IF(w->id, stdout_fd == -1);
     DIE_IF(w->id, !(e->in = _fdopen(stdout_fd, "r")));
     DIE_IF(w->id, !(e->out = _fdopen(stdin_fd, "w")));
+
+    // Bind child process and parent process to one job, so child process is
+    // killed when parent process exits
+    DIE_IF(w->id, !AssignProcessToJobObject(hJob, GetCurrentProcess()));
+    DIE_IF(w->id, !AssignProcessToJobObject(hJob, e->hProcess));
 #else
     // Pipe diagram: Parent -> [1]into[0] -> Child -> [1]outof[0] -> Parent
     // 'into' and 'outof' are pipes, each with 2 ends: read=0, write=1

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -14,17 +14,24 @@
  *  not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef __linux__
+#if defined(__MINGW32__)
+    #include <io.h>
+    #include <fcntl.h>
+    #include <windows.h> 
+#elif defined(__linux__)
     #define _GNU_SOURCE
     #include <unistd.h>
     #include <fcntl.h>
     #include <sys/prctl.h>
+    #include <sys/wait.h>
 #else
     #include <unistd.h>
+    #include <sys/wait.h>
 #endif
 
 #include <iostream>
 #include <sstream>
+#include <filesystem>
 #include <assert.h>
 #include <limits.h>
 #include <pthread.h>
@@ -32,18 +39,85 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/wait.h>
 
 #include "engine.h"
 #include "util.h"
 #include "vec.h"
 #include "position.h"
 
-static void engine_spawn(const Worker *w, Engine *e, const char *cwd, const char *run, char **argv,
+static void engine_spawn(const Worker *w, Engine *e, 
+    [[maybe_unused]] const char *cmd, const char *cwd, 
+    [[maybe_unused]] const char *run, [[maybe_unused]] char **argv, 
     bool readStdErr)
 {
     assert(argv[0]);
 
+#if defined(__MINGW32__)
+    SECURITY_ATTRIBUTES saAttr;
+    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+    saAttr.bInheritHandle = TRUE;
+    saAttr.lpSecurityDescriptor = NULL;
+
+    // Pipe handler: read=0, write=1
+    HANDLE p_stdin[2], p_stdout[2];
+
+    // Create a pipe for child process's STDOUT
+    DIE_IF(w->id, !CreatePipe(&p_stdout[0], &p_stdout[1], &saAttr, 0));
+    DIE_IF(w->id, !SetHandleInformation(p_stdout[0], HANDLE_FLAG_INHERIT, 0));
+
+    // Create a pipe for child process's STDIN
+    DIE_IF(w->id, !CreatePipe(&p_stdin[0], &p_stdin[1], &saAttr, 0));
+    DIE_IF(w->id, !SetHandleInformation(p_stdin[1], HANDLE_FLAG_INHERIT, 0));
+
+    // Create the child process
+    PROCESS_INFORMATION piProcInfo; 
+    STARTUPINFO siStartInfo;
+    ZeroMemory(&piProcInfo, sizeof(PROCESS_INFORMATION));
+    ZeroMemory( &siStartInfo, sizeof(STARTUPINFO) );
+    siStartInfo.cb = sizeof(STARTUPINFO); 
+    siStartInfo.hStdOutput = p_stdout[1];
+    siStartInfo.hStdInput = p_stdin[0];
+    if (readStdErr)
+        siStartInfo.hStdError = p_stdout[1];
+    siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
+
+    char fullcmd[32768];
+    strcpy_s(fullcmd, cmd);
+    const int flag = CREATE_NO_WINDOW | BELOW_NORMAL_PRIORITY_CLASS;
+
+
+    if (!CreateProcess(
+        NULL,           // application name
+        fullcmd,        // command line (non-const)
+        NULL,           // process security attributes
+        NULL,           // primary thread security attributes
+        TRUE,           // handles are inherited
+        flag,           // creation flags
+        NULL,           // use parent's environment
+        cwd,            // child process's current directory
+        &siStartInfo,   // STARTUPINFO pointer
+        &piProcInfo     // receives PROCESS_INFORMATION
+    ))
+        DIE("fail to execute engine cmdline %s\n", cmd);
+
+    // Keep the handle to the child process
+    e->pid = piProcInfo.dwProcessId;
+    e->hProcess = piProcInfo.hProcess;
+    // Close the handle to the child's primary thread
+    DIE_IF(w->id, !CloseHandle(piProcInfo.hThread));
+
+    // Close handles to the stdin and stdout pipes no longer needed
+    DIE_IF(w->id, !CloseHandle(p_stdin[0]));
+    DIE_IF(w->id, !CloseHandle(p_stdout[1]));
+
+    // Reopen stdin and stdout pipes using C style FILE
+    int stdin_fd = _open_osfhandle((intptr_t)p_stdin[1], _O_RDONLY | _O_TEXT);
+    int stdout_fd = _open_osfhandle((intptr_t)p_stdout[0], _O_RDONLY | _O_TEXT);
+    DIE_IF(w->id, stdin_fd == -1);
+    DIE_IF(w->id, stdout_fd == -1);
+    DIE_IF(w->id, !(e->in = _fdopen(stdout_fd, "r")));
+    DIE_IF(w->id, !(e->out = _fdopen(stdin_fd, "w")));
+#else
     // Pipe diagram: Parent -> [1]into[0] -> Child -> [1]outof[0] -> Parent
     // 'into' and 'outof' are pipes, each with 2 ends: read=0, write=1
     int outof[2] = {0}, into[2] = {0};
@@ -96,6 +170,7 @@ static void engine_spawn(const Worker *w, Engine *e, const char *cwd, const char
         DIE_IF(w->id, !(e->in = fdopen(outof[0], "r")));
         DIE_IF(w->id, !(e->out = fdopen(into[1], "w")));
     }
+#endif
 }
 
 static void engine_parse_cmd(const char *cmd, str_t *cwd, str_t *run, str_t **args)
@@ -126,7 +201,8 @@ static void engine_parse_cmd(const char *cmd, str_t *cwd, str_t *run, str_t **ar
         vec_push(*args, str_init_from(token), str_t);
 }
 
-void Engine::engine_init(Worker *w, const char *cmd, const char *engname, const str_t *options, bool debug)
+void Engine::engine_init(Worker *w, const char *cmd, const char *engname, 
+    [[maybe_unused]] const str_t *options, bool debug)
 {
     if (!*cmd)
         DIE("[%d] missing command to start engine.\n", w->id);
@@ -148,7 +224,7 @@ void Engine::engine_init(Worker *w, const char *cmd, const char *engname, const 
     }
 
     // Spawn child process and plug pipes
-    engine_spawn(w, this, cwd.buf, run.buf, argv, w->log != NULL);
+    engine_spawn(w, this, cmd, cwd.buf, run.buf, argv, w->log != NULL);
 
     vec_destroy_rec(args, str_destroy);
     free(argv);
@@ -175,7 +251,14 @@ void Engine::engine_destroy(Worker *w)
     // Order the engine to quit, and grant 1s deadline for obeying
     w->deadline_set(name.buf, system_msec() + 1000);
     engine_writeln(w, "END");
+
+#ifdef __MINGW32__
+    WaitForSingleObject((HANDLE)hProcess, INFINITE);
+    CloseHandle((HANDLE)hProcess);
+#else
     waitpid(pid, NULL, 0);
+#endif
+
     w->deadline_clear();
 
     str_destroy(&name);
@@ -372,6 +455,6 @@ void Engine::engine_process_message_ifneeded(const char *line)
     }
 }
 
-void Engine::engine_parse_thinking_messages(const char *line, Info *info)
+void Engine::engine_parse_thinking_messages([[maybe_unused]] const char *line, [[maybe_unused]] Info *info)
 {
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -15,10 +15,13 @@
  */
 
 #pragma once
+#ifndef __MINGW32__
+    #include <sys/types.h>
+#endif
+
 #include <cinttypes>
 #include <cstdbool>
 #include <cstdio>
-#include <sys/types.h>
 #include "str.h"
 #include "workers.h"
 
@@ -31,10 +34,15 @@ struct Info {
 // Engine process
 class Engine {
 public:
+#ifdef __MINGW32__
+    long  pid;
+    void* hProcess;
+#else
+    pid_t pid;
+#endif
 
     FILE *in, *out;
     str_t name;
-    pid_t pid;
     bool isDebug;
     char pad[3];
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -42,7 +42,7 @@ public:
     void engine_destroy(Worker *w);
 
     void engine_readln(const Worker *w, str_t *line);
-    void engine_writeln(const Worker *w, char *buf);
+    void engine_writeln(const Worker *w, const char *buf);
 
     void engine_sync(Worker *w);
     void engine_wait_for_ok(Worker *w);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,11 +69,11 @@ static void main_init(int argc, const char **argv)
     openings.openings_init(options.openings.buf, options.random, options.srand, 0);
 
     if (options.pgn.len) {
-        pgnSeqWriter.seq_writer_init(options.pgn.buf, "ae");
+        pgnSeqWriter.seq_writer_init(options.pgn.buf, FOPEN_APPEND_MODE);
     }
 
     if (options.sgf.len) {
-        sgfSeqWriter.seq_writer_init(options.sgf.buf, "ae");
+        sgfSeqWriter.seq_writer_init(options.sgf.buf, FOPEN_APPEND_MODE);
     }
 
     // Prepare Workers[]

--- a/src/openings.cpp
+++ b/src/openings.cpp
@@ -27,7 +27,7 @@ void Openings::openings_init(const char *fileName, bool random, uint64_t srand, 
     index = (long*) vec_init(size_t);
 
     if (*fileName) {
-        DIE_IF(threadId, !(file = fopen(fileName, "re")));
+        DIE_IF(threadId, !(file = fopen(fileName, FOPEN_READ_MODE)));
     }
 
     if (file) {

--- a/src/str.cpp
+++ b/src/str.cpp
@@ -317,10 +317,17 @@ size_t str_getline(str_t *out, FILE *in)
     str_resize(out, 0);
     int c;
 
+#ifndef __MINGW32__
     flockfile(in);
+#endif
 
     while (true) {
+#ifdef __MINGW32__
+        // TODO: find a faster replacement under windows
+        c = getc(in);
+#else
         c = getc_unlocked(in);
+#endif
 
         if (c != '\n' && c != EOF)
             str_push(out, (char)c);
@@ -328,7 +335,9 @@ size_t str_getline(str_t *out, FILE *in)
             break;
     }
 
+#ifndef __MINGW32__
     funlockfile(in);
+#endif
 
     const size_t n = out->len + (c == '\n');
 

--- a/src/util.h
+++ b/src/util.h
@@ -51,7 +51,9 @@ void system_sleep(int64_t msec);
 #ifdef __linux__
     #define FOPEN_READ_MODE "re"
     #define FOPEN_WRITE_MODE "we"
+    #define FOPEN_APPEND_MODE "ae"
 #else
     #define FOPEN_READ_MODE "r"
     #define FOPEN_WRITE_MODE "w"
+    #define FOPEN_APPEND_MODE "a"
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -47,3 +47,11 @@ void system_sleep(int64_t msec);
     if (v) \
         die_errno(id, __FILE__, __LINE__); \
 })
+
+#ifdef __linux__
+    #define FOPEN_READ_MODE "re"
+    #define FOPEN_WRITE_MODE "we"
+#else
+    #define FOPEN_READ_MODE "r"
+    #define FOPEN_WRITE_MODE "w"
+#endif

--- a/src/workers.cpp
+++ b/src/workers.cpp
@@ -61,7 +61,7 @@ void Worker::worker_init(int i, const char *logName)
 
     log = NULL;
     if (*logName) {
-        log = fopen(logName, "we");
+        log = fopen(logName, FOPEN_WRITE_MODE);
         DIE_IF(0, !log);
     }
 


### PR DESCRIPTION
Basic support for windows is added to c-gomoku-cli 😃 

The port may still not be perfect, for instance I did not find a valid replacement for `getc_unlocked()` in `str_getline()` under Windows, so a slower `getc()` is used instead. Other process related stuffs should be alright.

It builds successfully using MINGW64 gcc in my test.