### PR TITLE
Bug fixes and tweakable engine tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ c-gomoku-cli -each tc=180/30 \
 
  * `thread=N`: Number of threads a engine can use. Default value is `1`. This is an extension option[^1], may not be supported by all engines.
 
+ * `tolerance=N`: Tolerance (in seconds) to determine when an engine hangs (which is an unrecoverable error at this point). Default value is `N=3`.
+
  * `option.O=V`: Set a raw protocol info. Command `INFO [O] [V]` will be sent to the engine before each game starts.
 
    [^1]: Yixin-Board extension protocol: https://github.com/accreator/Yixin-protocol/blob/master/protocol.pdf

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -265,7 +265,7 @@ void Engine::engine_destroy(Worker *w)
     }
 
     // Order the engine to quit, and grant 1s deadline for obeying
-    w->deadline_set(name.buf, system_msec() + 1000);
+    w->deadline_set(name.buf, system_msec() + tolerance);
     engine_writeln(w, "END");
 
 #ifdef __MINGW32__
@@ -306,7 +306,7 @@ void Engine::engine_writeln(const Worker *w, const char *buf)
 
 void Engine::engine_wait_for_ok(Worker *w)
 {
-    w->deadline_set(name.buf, system_msec() + 4000);
+    w->deadline_set(name.buf, system_msec() + tolerance);
     scope(str_destroy) str_t line = str_init();
 
     do {
@@ -337,9 +337,9 @@ bool Engine::engine_bestmove(Worker *w, int64_t *timeLeft, int64_t maxTurnTime, 
         turnTimeLeft = min(*timeLeft, maxTurnTime);
     }
     
-    w->deadline_set(name.buf, turnTimeLimit + 1000);
+    w->deadline_set(name.buf, turnTimeLimit + tolerance);
 
-    while ((turnTimeLeft + 1000) >= 0 && !result) {
+    while ((turnTimeLeft + tolerance) >= 0 && !result) {
         engine_readln(w, &line);
 
         const int64_t now = system_msec();
@@ -439,7 +439,7 @@ static void parse_and_display_engine_about(str_t &line, str_t* engine_name) {
 
 // process engine ABOUT command
 void Engine::engine_about(Worker *w, const char* fallbackName) {
-    w->deadline_set(*name.buf ? name.buf : fallbackName, system_msec() + 2000);
+    w->deadline_set(*name.buf ? name.buf : fallbackName, system_msec() + tolerance);
     engine_writeln(w, "ABOUT");
     scope(str_destroy) str_t line = str_init();
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -31,6 +31,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <filesystem>
 #include <assert.h>
 #include <limits.h>
 #include <pthread.h>
@@ -96,15 +97,17 @@ static void engine_spawn(const Worker *w, Engine *e,
     char fullrun[MAX_PATH];
     char fullcmd[32768];
     strcpy_s(fullrun, cwd);
-    strcat_s(fullrun, run + 1); // we need an absolute path to execute the engine
+    strcat_s(fullrun, run + 1); // we need an path relative to the cli
 
-    strcpy_s(fullcmd, run); // a reletive path for engine argv[0]
+    // Use an absolute path for engine argv[0]
+    strcpy_s(fullcmd, std::filesystem::absolute(fullrun).string().c_str()); 
     for (size_t i = 1; argv[i]; i++) {  // argv[0] == run
         strcat_s(fullcmd, " ");
         strcat_s(fullcmd, argv[i]);
     }
 
     const int flag = CREATE_NO_WINDOW | BELOW_NORMAL_PRIORITY_CLASS;
+    // FIXME: fullrun, fullcmd, cwd conversion to LPCWSTR
     if (!CreateProcess(
         fullrun,        // application name
         fullcmd,        // command line (non-const)

--- a/src/engine.h
+++ b/src/engine.h
@@ -44,6 +44,7 @@ public:
     FILE *in, *out;
     str_t name;
     str_t *messages;
+    int64_t tolerance;
     bool isDebug;
     char pad[3];
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -371,7 +371,7 @@ int Game::game_play(Worker *w, const Options *o, Engine engines[2],
 void Game::game_decode_state(str_t *result, str_t *reason, const char* restxt[3]) const
 {
     const char* DefaultResultTxt[3] = {
-        "0-1", "1/2-1/2", "1-0"
+        "1-0", "1/2-1/2", "0-1"
     };
     if (!restxt)
         restxt = DefaultResultTxt;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,11 +148,13 @@ static void *thread_start(void *arg)
         // Engine stop/start, as needed
         for (int i = 0; i < 2; i++) {
             if (job.ei[i] != ei[i]) {
+                ei[i] = job.ei[i];
+                engines[i].tolerance = eo[ei[i]].tolerance;
+
                 if (engines[i].pid) {
                     engines[i].engine_destroy(w);
                 }
 
-                ei[i] = job.ei[i];
                 engines[i].engine_init(w, eo[ei[i]].cmd.buf, eo[ei[i]].name.buf, options.debug, msg);
                 jq.job_queue_set_name(ei[i], engines[i].name.buf);
             }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -72,6 +72,8 @@ static int options_parse_eo(int argc, const char **argv, int i, EngineOptions *e
             eo->maxMemory = (int64_t)(atof(tail));
         } else if ((tail = str_prefix(argv[i], "thread="))) {
             eo->numThreads = atoi(tail);
+        } else if ((tail = str_prefix(argv[i], "tolerance="))) {
+            eo->tolerance = (int64_t)(atof(tail) * 1000);
         } else if ((tail = str_prefix(argv[i], "option."))) {
             vec_push(eo->options, str_init_from_c(tail), str_t);  // store "name=value" string
         } else {
@@ -212,6 +214,8 @@ EngineOptions engine_options_init(void)
     eo.maxMemory = 367001600;
     // default thread num is 1
     eo.numThreads = 1;
+    // default tolerance is 3
+    eo.tolerance = 3000;
 
     return eo;
 }
@@ -412,6 +416,7 @@ void options_print(Options *o, EngineOptions **eo) {
         std::cout << "increment = " << e1->increment << std::endl;
         std::cout << "maxMemory = " << e1->maxMemory << std::endl;
         std::cout << "thread = " << e1->numThreads << std::endl;
+        std::cout << "tolerance = " << e1->tolerance << std::endl;
         for (size_t i = 0; i < vec_size(e1->options); i++) {
             std::cout << "option." << e1->options[i].buf << std::endl;
         }

--- a/src/options.h
+++ b/src/options.h
@@ -51,6 +51,7 @@ struct EngineOptions {
     int64_t timeoutTurn, timeoutMatch, increment, nodes;
     int depth, numThreads;
     int64_t maxMemory;
+    int64_t tolerance;
 };
 
 EngineOptions engine_options_init(void);

--- a/src/str.cpp
+++ b/src/str.cpp
@@ -317,14 +317,15 @@ size_t str_getline(str_t *out, FILE *in)
     str_resize(out, 0);
     int c;
 
-#ifndef __MINGW32__
+#ifdef __MINGW32__
+    _lock_file(in);
+#else
     flockfile(in);
 #endif
 
     while (true) {
 #ifdef __MINGW32__
-        // TODO: find a faster replacement under windows
-        c = getc(in);
+        c = _getc_nolock(in);
 #else
         c = getc_unlocked(in);
 #endif
@@ -335,7 +336,9 @@ size_t str_getline(str_t *out, FILE *in)
             break;
     }
 
-#ifndef __MINGW32__
+#ifdef __MINGW32__
+    _unlock_file(in);
+#else
     funlockfile(in);
 #endif
 


### PR DESCRIPTION
Hi Chao Ma,

This PR contains 4 changes:
1. Fixed incorrect pgn result. I mistakenly swaped black and white on writing PGN files, causing an opposite result to be saved. This is a severe bug, however I only noticed it when I saw reversed ranking in bayeselo :(
2. Fixed argv[0] passed to the engine (which now is an absolute path). Some engines can not start if argv[0] is incorrect.
3. Added a tweakable engine tolerance. (Code from ![this commit](https://github.com/lucasart/c-chess-cli/commit/b29a2d394498cc358d525c0d8944ed0ea8d7d0bf))
4. Fixed slower `getc()` to `_getc_nolock()`.