### PR TITLE
Fix move format in binary sample

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -587,7 +587,8 @@ void Game::export_samples_bin(FILE *out, LZ4F_compressionContext_t lz4Ctx) const
         e.head.result    = samples[i].result;
         e.head.move      = samples[i].move;
         for (int iMove = 0; iMove < moveply; iMove++) {
-            e.position[iMove] = PosFromMove(hist_moves[iMove]);
+            Pos pos           = PosFromMove(hist_moves[iMove]);
+            e.position[iMove] = POS_RAW(CoordX(pos), CoordY(pos));
         }
 
         const size_t entrySize = sizeof(Entry::EntryHead) + sizeof(uint16_t) * moveply;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -432,7 +432,6 @@ std::string Game::export_pgn(size_t gameIdx, int verbosity) const
     out += format("%s\n", timeBuffer);
 
     out += format("[Round \"%i.%i\"]\n", round + 1, game + 1);
-    out += format("[Round \"%i.%i\"]\n", round + 1, game + 1);
     out += format("[Black \"%s\"]\n", names[BLACK]);
     out += format("[White \"%s\"]\n", names[WHITE]);
 


### PR DESCRIPTION
Fixes two bugs:

1. c-gomoku-cli uses offset in move coordinate internally, which does not match the binary format specification in README. This patch fixes that.
2. Remove duplicate line in PGN